### PR TITLE
Исправление шипсканера.

### DIFF
--- a/src/cr0s/WarpDrive/machines/TileEntityShipScanner.java
+++ b/src/cr0s/WarpDrive/machines/TileEntityShipScanner.java
@@ -8,6 +8,7 @@ import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.lua.ILuaContext;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import ic2.api.energy.tile.IEnergyTile;
+import cofh.api.energy.IEnergyHandler;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -294,6 +295,13 @@ public class TileEntityShipScanner extends WarpEnergyTE implements IPeripheral {
 									}
 								}
 								
+								if (te instanceof IEnergyHandler) {
+									// Thermal Expansion
+									if (tileTag.hasKey("Energy")) {
+										tileTag.setInteger("Energy", 0);
+									}
+								}
+
 								// Transform TE's coordinates from local axis to .schematic offset-axis
 								tileTag.setInteger("x", te.xCoord - core.minX);
 								tileTag.setInteger("y", te.yCoord - core.minY);


### PR DESCRIPTION
В шипсканере не был переопределен метод getMaxEnergyStored, из-за чего он не принимал энергию.
И еще поставь форестри.
